### PR TITLE
Handle blocked xlsx library with download step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore Python virtual environment
+venv/
+
+# Ignore downloaded JS libraries
+libs/xlsx.full.min.js
+
+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ For more details, please read: Interaction Matters: A Three-Level Multi-class En
 
 Dialogues labelled for three levels (from the above paper) can be found in SLDEA data.
 
-Features exacted from the annotated datasets can be found in feature_label.csv. 
+Features extracted from the annotated datasets can be found in feature_label.csv.
+
+### Setup
+
+Run `setup.sh` to install Python dependencies and automatically download the
+`xlsx.full.min.js` library used by the Gradio interface. This avoids storing the
+large minified file in the repository while still making it available at runtime.
 
 Python script data/explore_data.py provides an example of interfacing with the data.
 

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,0 +1,1 @@
+This directory will hold third-party JavaScript libraries required at runtime.

--- a/setup.sh
+++ b/setup.sh
@@ -16,6 +16,14 @@ pip install --upgrade pip
 # Install dependencies
 pip install -r requirements.txt
 
+# Download required JavaScript libraries
+mkdir -p libs
+XLXS_JS_URL="https://cdn.sheetjs.com/xlsx-latest/package/dist/xlsx.full.min.js"
+if [ ! -f libs/xlsx.full.min.js ]; then
+    echo "Downloading xlsx.full.min.js from $XLXS_JS_URL"
+    wget -q -O libs/xlsx.full.min.js "$XLXS_JS_URL"
+fi
+
 cat <<'INSTRUCTIONS'
 
 The environment is now prepared. To convert the sample Excel files to CSV and


### PR DESCRIPTION
## Summary
- add `.gitignore` for venv and the large JS file
- download `xlsx.full.min.js` during setup instead of keeping it in git
- document the new setup instructions in README
- create `libs/` directory with README placeholder

## Testing
- `bash -n setup.sh`